### PR TITLE
Make giveReward private

### DIFF
--- a/contracts/TokenQuarry.sol
+++ b/contracts/TokenQuarry.sol
@@ -113,6 +113,7 @@ function getRewardAmount(address token) public constant returns (uint)
 }
 
 function giveReward(address tokenAddress,address recipient)
+private
 {
      uint amount = getRewardAmount(tokenAddress);
 


### PR DESCRIPTION
giveReward is public by default, meaning anyone can call into it and drain the wallet. making the method private ensures that it will only be called by mineQuarry